### PR TITLE
Deps changes

### DIFF
--- a/lib-dyn/deps.ts
+++ b/lib-dyn/deps.ts
@@ -4,16 +4,16 @@ export const tarn = dex_tarn;
 import dex_inherits from "https://dev.jspm.io/inherits@2.0";
 export const inherits = dex_inherits;
 
-import dex_events from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/events.js";
+import dex_events from "https://deno.land/std/node/events.ts";
 export const events = dex_events;
 
-import dex_util from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/util.js";
+import dex_util from "https://deno.land/std/node/util.ts";
 export const util = dex_util;
 
 import dex_lodash from "https://dev.jspm.io/lodash@4";
 export const _ = dex_lodash;
 
-import dex_debug from "https://dev.jspm.io/debug@4.1.1";
+import dex_debug from "https://dev.jspm.io/debug@4";
 export const debug = dex_debug;
 
 import * as dex_colors from "https://deno.land/std/fmt/colors.ts";
@@ -25,14 +25,14 @@ export const uuid = dex_uuid;
 import * as dex_path from "https://deno.land/std/path/mod.ts";
 export const path = dex_path;
 
-import dex_assert from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/assert.js";
+import dex_assert from "https://deno.land/std/node/assert.ts";
 export const assert = dex_assert;
 
-import dex_url from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/url.js";
+import dex_url from "https://deno.land/std/node/url.ts";
 export const url = dex_url;
 
-import dex_pgconn from "https://dev.jspm.io/pg-connection-string@2.2.0";
+import dex_pgconn from "https://dev.jspm.io/pg-connection-string@2.5.0";
 export const pgconn = dex_pgconn;
 
-import dex_stream from "https://raw.githubusercontent.com/jspm/jspm-core/master/nodelibs/stream.js";
+import dex_stream from "https://deno.land/std/node/stream.ts";
 export const stream = dex_stream;

--- a/lib-dyn/deps.ts
+++ b/lib-dyn/deps.ts
@@ -4,10 +4,10 @@ export const tarn = dex_tarn;
 import dex_inherits from "https://dev.jspm.io/inherits@2.0";
 export const inherits = dex_inherits;
 
-import dex_events from "https://deno.land/std@0.176.0/node/events.ts";
+import dex_events from "https://deno.land/std@0.177.0/node/events.ts";
 export const events = dex_events;
 
-import dex_util from "https://deno.land/std@0.176.0/node/util.ts";
+import dex_util from "https://deno.land/std@0.177.0/node/util.ts";
 export const util = dex_util;
 
 import dex_lodash from "https://dev.jspm.io/lodash@4";
@@ -16,23 +16,23 @@ export const _ = dex_lodash;
 import dex_debug from "https://dev.jspm.io/debug@4";
 export const debug = dex_debug;
 
-import * as dex_colors from "https://deno.land/std@0.176.0/fmt/colors.ts";
+import * as dex_colors from "https://deno.land/std@0.177.0/fmt/colors.ts";
 export const colors = dex_colors;
 
-import * as dex_uuid from "https://deno.land/std@0.176.0/uuid/mod.ts";
+import * as dex_uuid from "https://deno.land/std@0.177.0/uuid/mod.ts";
 export const uuid = dex_uuid;
 
-import * as dex_path from "https://deno.land/std@0.176.0/path/mod.ts";
+import * as dex_path from "https://deno.land/std@0.177.0/path/mod.ts";
 export const path = dex_path;
 
-import dex_assert from "https://deno.land/std@0.176.0/node/assert.ts";
+import dex_assert from "https://deno.land/std@0.177.0/node/assert.ts";
 export const assert = dex_assert;
 
-import dex_url from "https://deno.land/std@0.176.0/node/url.ts";
+import dex_url from "https://deno.land/std@0.177.0/node/url.ts";
 export const url = dex_url;
 
 import dex_pgconn from "https://dev.jspm.io/pg-connection-string@2.5.0";
 export const pgconn = dex_pgconn;
 
-import dex_stream from "https://deno.land/std@0.176.0/node/stream.ts";
+import dex_stream from "https://deno.land/std@0.177.0/node/stream.ts";
 export const stream = dex_stream;

--- a/lib-dyn/deps.ts
+++ b/lib-dyn/deps.ts
@@ -4,10 +4,10 @@ export const tarn = dex_tarn;
 import dex_inherits from "https://dev.jspm.io/inherits@2.0";
 export const inherits = dex_inherits;
 
-import dex_events from "https://deno.land/std/node/events.ts";
+import dex_events from "https://deno.land/std@0.176.0/node/events.ts";
 export const events = dex_events;
 
-import dex_util from "https://deno.land/std/node/util.ts";
+import dex_util from "https://deno.land/std@0.176.0/node/util.ts";
 export const util = dex_util;
 
 import dex_lodash from "https://dev.jspm.io/lodash@4";
@@ -16,23 +16,23 @@ export const _ = dex_lodash;
 import dex_debug from "https://dev.jspm.io/debug@4";
 export const debug = dex_debug;
 
-import * as dex_colors from "https://deno.land/std/fmt/colors.ts";
+import * as dex_colors from "https://deno.land/std@0.176.0/fmt/colors.ts";
 export const colors = dex_colors;
 
-import * as dex_uuid from "https://deno.land/std/uuid/mod.ts";
+import * as dex_uuid from "https://deno.land/std@0.176.0/uuid/mod.ts";
 export const uuid = dex_uuid;
 
-import * as dex_path from "https://deno.land/std/path/mod.ts";
+import * as dex_path from "https://deno.land/std@0.176.0/path/mod.ts";
 export const path = dex_path;
 
-import dex_assert from "https://deno.land/std/node/assert.ts";
+import dex_assert from "https://deno.land/std@0.176.0/node/assert.ts";
 export const assert = dex_assert;
 
-import dex_url from "https://deno.land/std/node/url.ts";
+import dex_url from "https://deno.land/std@0.176.0/node/url.ts";
 export const url = dex_url;
 
 import dex_pgconn from "https://dev.jspm.io/pg-connection-string@2.5.0";
 export const pgconn = dex_pgconn;
 
-import dex_stream from "https://deno.land/std/node/stream.ts";
+import dex_stream from "https://deno.land/std@0.176.0/node/stream.ts";
 export const stream = dex_stream;

--- a/lib-dyn/query/string.js
+++ b/lib-dyn/query/string.js
@@ -1,5 +1,5 @@
 /*eslint max-len: 0, no-var:0 */
-
+import { Buffer } from 'node:buffer';
 export const charsRegex = /[\0\b\t\n\r\x1a"'\\]/g; // eslint-disable-line no-control-regex
 export const charsMap = {
   '\0': '\\0',


### PR DESCRIPTION
The std dependencies can be updated one more minor revision form 76 to 77. Also imported buffer in `lib-dyn/query/string.js` because it was throwing an error about not being imported